### PR TITLE
Add Jenkinsfile and Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,6 @@ build:
 	npm install -g yarn@1.5.1
 	yarn --version
 	yarn
+	yarn lint
+	yarn lint-styles
 	yarn build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+build:
+	npm --version
+	node --version
+	npm install -g yarn@1.5.1
+	yarn --version
+	yarn
+	yarn build

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,4 +1,4 @@
 website([
-  website: 'ipfs.io',
-  record: '_dnslink.conference'
+  website: 'conf.ipfs.io',
+  record: '_dnslink'
 ])

--- a/ci/Jenkinsfile
+++ b/ci/Jenkinsfile
@@ -1,0 +1,4 @@
+website([
+  website: 'ipfs.io',
+  record: '_dnslink.conference'
+])

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lint-styles-fix": "stylelint \"src/**/*.scss\" --fix",
     "develop": "gatsby develop",
     "build": "gatsby build",
-    "deploy": "gatsby build --prefix-paths && gh-pages -d public"
+    "deploy": "gatsby build --prefix-paths"
   },
   "devDependencies": {
     "babel-eslint": "^8.2.1",


### PR DESCRIPTION
Adds a Jenkinsfile which does Previews for the PRs and deploys when master changes.

Add Makefile which the jenkins pipeline uses to do the build.

Removed `gh-pages -d public` as that's not how we'll be doing deploys. Haven't removed it from the list of modules in `package.json` though as I didn't look if it's being used elsewhere.